### PR TITLE
[WIP] Update GrpcStatusFunction to let it return Metadata

### DIFF
--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/ArmeriaGrpcStatus.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/ArmeriaGrpcStatus.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021 LINE Corporation
+ *
+ * LINE Corporation licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+package com.linecorp.armeria.common.grpc;
+
+import javax.annotation.Nullable;
+
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.Status.Code;
+
+/**
+ * Holds {@link Status} and {@link Metadata}.
+ */
+public class ArmeriaGrpcStatus {
+
+    private final Status status;
+
+    private final Metadata metadata;
+
+    ArmeriaGrpcStatus(Status status, @Nullable Metadata metadata) {
+        this.status = status;
+        this.metadata = metadata == null ? new Metadata() : metadata;
+    }
+
+    /**
+     * Returns {@link ArmeriaGrpcStatus}.
+     */
+    public static ArmeriaGrpcStatus of(Status status) {
+        return new ArmeriaGrpcStatus(status, null);
+    }
+
+    /**
+     * Returns {@link ArmeriaGrpcStatus}.
+     */
+    public static ArmeriaGrpcStatus of(Status status, Metadata metadata) {
+        return new ArmeriaGrpcStatus(status, metadata);
+    }
+
+    /**
+     * Returns {@link Status}.
+     */
+    public Status get() {
+        return status;
+    }
+
+    /**
+     * Returns {@link Metadata}.
+     */
+    public Metadata getMetadata() {
+        return metadata;
+    }
+
+    /**
+     * Returns {@link Code}.
+     */
+    public Code getCode() {
+        return status.getCode();
+    }
+
+    /**
+     * Returns a cause {@link Throwable} of an error.
+     */
+    @Nullable
+    public Throwable getCause() {
+        return status.getCause();
+    }
+
+    /**
+     * Creates a new instance of {@link ArmeriaGrpcStatus} derived from this instance with the given cause.
+     */
+    public ArmeriaGrpcStatus withCause(Throwable cause) {
+        return ArmeriaGrpcStatus.of(status.withCause(cause), metadata);
+    }
+}

--- a/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcStatusFunction.java
+++ b/grpc/src/main/java/com/linecorp/armeria/common/grpc/GrpcStatusFunction.java
@@ -22,20 +22,18 @@ import javax.annotation.Nullable;
 
 import com.linecorp.armeria.common.annotation.UnstableApi;
 
-import io.grpc.Status;
-
 /**
- * A mapping function that converts a {@link Throwable} into a gRPC {@link Status}.
+ * A mapping function that converts a {@link Throwable} into an {@link ArmeriaGrpcStatus}.
  */
 @UnstableApi
 @FunctionalInterface
-public interface GrpcStatusFunction extends Function<Throwable, Status> {
+public interface GrpcStatusFunction extends Function<Throwable, ArmeriaGrpcStatus> {
 
     /**
-     * Maps the specified {@link Throwable} to a gRPC {@link Status}.
+     * Maps the specified {@link Throwable} to an {@link ArmeriaGrpcStatus}.
      * If {@code null} is returned, the built-in mapping rule is used by default.
      */
     @Nullable
     @Override
-    Status apply(Throwable throwable);
+    ArmeriaGrpcStatus apply(Throwable throwable);
 }

--- a/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
+++ b/grpc/src/main/java/com/linecorp/armeria/internal/common/grpc/HttpStreamDeframer.java
@@ -26,6 +26,7 @@ import com.linecorp.armeria.common.HttpHeaders;
 import com.linecorp.armeria.common.HttpObject;
 import com.linecorp.armeria.common.HttpStatus;
 import com.linecorp.armeria.common.RequestHeaders;
+import com.linecorp.armeria.common.grpc.ArmeriaGrpcStatus;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.common.grpc.protocol.ArmeriaMessageDeframer;
 import com.linecorp.armeria.common.grpc.protocol.Decompressor;
@@ -109,7 +110,9 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
             try {
                 decompressor(ForwardingDecompressor.forGrpc(decompressor));
             } catch (Throwable t) {
-                transportStatusListener.transportReportStatus(GrpcStatus.fromThrowable(statusFunction, t));
+                final ArmeriaGrpcStatus armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, t);
+                transportStatusListener.transportReportStatus(
+                        armeriaGrpcStatus.get(), armeriaGrpcStatus.getMetadata());
             }
         }
     }
@@ -125,7 +128,9 @@ public final class HttpStreamDeframer extends ArmeriaMessageDeframer {
 
     @Override
     public void processOnError(Throwable cause) {
-        transportStatusListener.transportReportStatus(GrpcStatus.fromThrowable(statusFunction, cause));
+        final ArmeriaGrpcStatus armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, cause);
+        transportStatusListener.transportReportStatus(
+                armeriaGrpcStatus.get(), armeriaGrpcStatus.getMetadata());
     }
 
     @Override

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcServiceBuilderTest.java
@@ -20,15 +20,16 @@ import static com.linecorp.armeria.server.grpc.GrpcServiceBuilder.toGrpcStatusFu
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
 import com.google.common.collect.ImmutableList;
 
+import com.linecorp.armeria.common.grpc.ArmeriaGrpcStatus;
 import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.grpc.testing.MetricsServiceGrpc.MetricsServiceImplBase;
 import com.linecorp.armeria.grpc.testing.ReconnectServiceGrpc.ReconnectServiceImplBase;
@@ -47,19 +48,34 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.Status;
+import io.grpc.Status.Code;
 
 class GrpcServiceBuilderTest {
 
     @Test
     void mixExceptionMappingAndGrpcStatusFunction() {
+        final Function<Throwable, Status> fun1 = cause -> Status.PERMISSION_DENIED;
         assertThatThrownBy(() -> GrpcService.builder()
                                             .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED)
-                                            .exceptionMapping(cause -> Status.PERMISSION_DENIED))
+                                            .exceptionMapping(fun1))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("exceptionMapping() and addExceptionMapping() are mutually exclusive.");
 
         assertThatThrownBy(() -> GrpcService.builder()
-                                            .exceptionMapping(cause -> Status.PERMISSION_DENIED)
+                                            .exceptionMapping(fun1)
+                                            .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("addExceptionMapping() and exceptionMapping() are mutually exclusive.");
+
+        final GrpcStatusFunction fun2 = cause -> ArmeriaGrpcStatus.of(Status.PERMISSION_DENIED);
+        assertThatThrownBy(() -> GrpcService.builder()
+                                            .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED)
+                                            .exceptionMapping(fun2))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("exceptionMapping() and addExceptionMapping() are mutually exclusive.");
+
+        assertThatThrownBy(() -> GrpcService.builder()
+                                            .exceptionMapping(fun2)
                                             .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED))
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("addExceptionMapping() and exceptionMapping() are mutually exclusive.");
@@ -67,80 +83,127 @@ class GrpcServiceBuilderTest {
 
     @Test
     void duplicatedExceptionMappings() {
-        final LinkedList<Map.Entry<Class<? extends Throwable>, Status>> exceptionMappings = new LinkedList<>();
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.RESOURCE_EXHAUSTED);
+        final LinkedList<Map.Entry<Class<? extends Throwable>, GrpcStatusFunction>> exceptionMappings =
+                new LinkedList<>();
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.RESOURCE_EXHAUSTED,
+                                               null);
 
         assertThatThrownBy(() -> {
-            GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.UNIMPLEMENTED);
+            GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.UNIMPLEMENTED,
+                                                   null);
+        }).isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("is already added with");
+
+        assertThatThrownBy(() -> {
+            GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.UNIMPLEMENTED,
+                                                   throwable -> new Metadata());
         }).isInstanceOf(IllegalArgumentException.class)
           .hasMessageContaining("is already added with");
     }
 
     @Test
     void sortExceptionMappings() {
-        final LinkedList<Map.Entry<Class<? extends Throwable>, Status>> exceptionMappings = new LinkedList<>();
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.RESOURCE_EXHAUSTED);
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A2Exception.class, Status.UNIMPLEMENTED);
+        final LinkedList<Map.Entry<Class<? extends Throwable>, GrpcStatusFunction>> exceptionMappings =
+                new LinkedList<>();
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A1Exception.class, Status.RESOURCE_EXHAUSTED,
+                                               null);
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A2Exception.class, Status.UNIMPLEMENTED,
+                                               null);
 
-        assertThat(exceptionMappings)
-                .containsExactly(new SimpleImmutableEntry<>(A2Exception.class, Status.UNIMPLEMENTED),
-                                 new SimpleImmutableEntry<>(A1Exception.class, Status.RESOURCE_EXHAUSTED));
+        assertThat(exceptionMappings.stream().map(it -> (Class) it.getKey()))
+                .containsExactly(A2Exception.class, A1Exception.class);
 
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, B1Exception.class, Status.UNAUTHENTICATED);
-        assertThat(exceptionMappings)
-                .containsExactly(new SimpleImmutableEntry<>(A2Exception.class, Status.UNIMPLEMENTED),
-                                 new SimpleImmutableEntry<>(A1Exception.class, Status.RESOURCE_EXHAUSTED),
-                                 new SimpleImmutableEntry<>(B1Exception.class, Status.UNAUTHENTICATED));
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, B1Exception.class, Status.UNAUTHENTICATED,
+                                               throwable -> new Metadata());
+        assertThat(exceptionMappings.stream().map(it -> (Class) it.getKey()))
+                .containsExactly(A2Exception.class,
+                                 A1Exception.class,
+                                 B1Exception.class);
 
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A3Exception.class, Status.UNAUTHENTICATED);
-        assertThat(exceptionMappings)
-                .containsExactly(new SimpleImmutableEntry<>(A3Exception.class, Status.UNAUTHENTICATED),
-                                 new SimpleImmutableEntry<>(A2Exception.class, Status.UNIMPLEMENTED),
-                                 new SimpleImmutableEntry<>(A1Exception.class, Status.RESOURCE_EXHAUSTED),
-                                 new SimpleImmutableEntry<>(B1Exception.class, Status.UNAUTHENTICATED));
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A3Exception.class, Status.UNAUTHENTICATED,
+                                               throwable -> new Metadata());
+        assertThat(exceptionMappings.stream().map(it -> (Class) it.getKey()))
+                .containsExactly(A3Exception.class,
+                                 A2Exception.class,
+                                 A1Exception.class,
+                                 B1Exception.class);
 
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, B2Exception.class, Status.NOT_FOUND);
-        assertThat(exceptionMappings)
-                .containsExactly(new SimpleImmutableEntry<>(A3Exception.class, Status.UNAUTHENTICATED),
-                                 new SimpleImmutableEntry<>(A2Exception.class, Status.UNIMPLEMENTED),
-                                 new SimpleImmutableEntry<>(A1Exception.class, Status.RESOURCE_EXHAUSTED),
-                                 new SimpleImmutableEntry<>(B2Exception.class, Status.NOT_FOUND),
-                                 new SimpleImmutableEntry<>(B1Exception.class, Status.UNAUTHENTICATED));
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, B2Exception.class, Status.NOT_FOUND, null);
+        assertThat(exceptionMappings.stream().map(it -> (Class) it.getKey()))
+                .containsExactly(A3Exception.class,
+                                 A2Exception.class,
+                                 A1Exception.class,
+                                 B2Exception.class,
+                                 B1Exception.class);
 
         final GrpcStatusFunction statusFunction = toGrpcStatusFunction(exceptionMappings);
 
-        Status status = GrpcStatus.fromThrowable(statusFunction, new A3Exception());
-        assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
+        ArmeriaGrpcStatus armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, new A3Exception());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.UNAUTHENTICATED);
 
-        status = GrpcStatus.fromThrowable(statusFunction, new A2Exception());
-        assertThat(status.getCode()).isEqualTo(Status.UNIMPLEMENTED.getCode());
+        armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, new A2Exception());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.UNIMPLEMENTED);
 
-        status = GrpcStatus.fromThrowable(statusFunction, new A1Exception());
-        assertThat(status.getCode()).isEqualTo(Status.RESOURCE_EXHAUSTED.getCode());
+        armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, new A1Exception());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
 
-        status = GrpcStatus.fromThrowable(statusFunction, new B2Exception());
-        assertThat(status.getCode()).isEqualTo(Status.NOT_FOUND.getCode());
+        armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, new B2Exception());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.NOT_FOUND);
 
-        status = GrpcStatus.fromThrowable(statusFunction, new B1Exception());
-        assertThat(status.getCode()).isEqualTo(Status.UNAUTHENTICATED.getCode());
+        armeriaGrpcStatus = GrpcStatus.fromThrowable(statusFunction, new B1Exception());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.UNAUTHENTICATED);
     }
 
     @Test
     void mapStatus() {
-        final LinkedList<Map.Entry<Class<? extends Throwable>, Status>> exceptionMappings = new LinkedList<>();
-        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A2Exception.class, Status.PERMISSION_DENIED);
+        final LinkedList<Map.Entry<Class<? extends Throwable>, GrpcStatusFunction>> exceptionMappings =
+                new LinkedList<>();
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, A2Exception.class, Status.PERMISSION_DENIED,
+                                               null);
         final GrpcStatusFunction statusFunction = toGrpcStatusFunction(exceptionMappings);
 
         for (Throwable ex : ImmutableList.of(new A2Exception(), new A3Exception())) {
             final Status status = Status.UNKNOWN.withCause(ex);
-            final Status newStatus = GrpcStatus.fromStatusFunction(statusFunction, status);
-            assertThat(newStatus.getCode()).isEqualTo(Status.PERMISSION_DENIED.getCode());
-            assertThat(newStatus.getCause()).isEqualTo(ex);
+            final ArmeriaGrpcStatus armeriaGrpcStatus =
+                    GrpcStatus.fromStatusFunction(statusFunction, status, new Metadata());
+            assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.PERMISSION_DENIED);
+            assertThat(armeriaGrpcStatus.getCause()).isEqualTo(ex);
+            assertThat(armeriaGrpcStatus.getMetadata().keys()).isEmpty();
         }
 
         final Status status = Status.DEADLINE_EXCEEDED.withCause(new A1Exception());
-        final Status newStatus = GrpcStatus.fromStatusFunction(statusFunction, status);
-        assertThat(newStatus).isSameAs(status);
+        final ArmeriaGrpcStatus armeriaGrpcStatus =
+                GrpcStatus.fromStatusFunction(statusFunction, status, new Metadata());
+        assertThat(armeriaGrpcStatus.get()).isSameAs(status);
+        assertThat(armeriaGrpcStatus.getMetadata().keys()).isEmpty();
+    }
+
+    @Test
+    void mapStatusAndMetadata() {
+        final LinkedList<Map.Entry<Class<? extends Throwable>, GrpcStatusFunction>> exceptionMappings =
+                new LinkedList<>();
+        GrpcServiceBuilder.addExceptionMapping(exceptionMappings, B1Exception.class, Status.ABORTED,
+                                               throwable -> {
+                                                   final Metadata metadata = new Metadata();
+                                                   metadata.put(TEST_KEY, throwable.getClass().getSimpleName());
+                                                   return metadata;
+                                               });
+        final GrpcStatusFunction statusFunction = toGrpcStatusFunction(exceptionMappings);
+
+        final Status status = Status.UNKNOWN.withCause(new B1Exception());
+
+        ArmeriaGrpcStatus armeriaGrpcStatus =
+                GrpcStatus.fromStatusFunction(statusFunction, status, new Metadata());
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.ABORTED);
+        assertThat(armeriaGrpcStatus.getMetadata().get(TEST_KEY)).isEqualTo("B1Exception");
+        assertThat(armeriaGrpcStatus.getMetadata().keys()).containsOnly(TEST_KEY.name());
+
+        final Metadata metadata = new Metadata();
+        metadata.put(TEST_KEY2, "test");
+        armeriaGrpcStatus = GrpcStatus.fromStatusFunction(statusFunction, status, metadata);
+        assertThat(armeriaGrpcStatus.getCode()).isEqualTo(Code.ABORTED);
+        assertThat(armeriaGrpcStatus.getMetadata().get(TEST_KEY)).isEqualTo("B1Exception");
+        assertThat(armeriaGrpcStatus.getMetadata().keys()).containsOnly(TEST_KEY.name(), TEST_KEY2.name());
     }
 
     @Test
@@ -194,4 +257,10 @@ class GrpcServiceBuilderTest {
             return next.startCall(call, headers);
         }
     }
+
+    private static final Metadata.Key<String> TEST_KEY =
+            Metadata.Key.of("test_key", Metadata.ASCII_STRING_MARSHALLER);
+
+    private static final Metadata.Key<String> TEST_KEY2 =
+            Metadata.Key.of("test_key2", Metadata.ASCII_STRING_MARSHALLER);
 }

--- a/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
+++ b/grpc/src/test/java/com/linecorp/armeria/server/grpc/GrpcStatusMappingTest.java
@@ -17,14 +17,16 @@
 package com.linecorp.armeria.server.grpc;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
-import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -33,8 +35,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 
+import com.google.common.collect.ImmutableMap;
+
 import com.linecorp.armeria.client.Clients;
+import com.linecorp.armeria.common.grpc.ArmeriaGrpcStatus;
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats;
+import com.linecorp.armeria.common.grpc.GrpcStatusFunction;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleRequest;
 import com.linecorp.armeria.grpc.testing.Messages.SimpleResponse;
 import com.linecorp.armeria.grpc.testing.TestServiceGrpc;
@@ -50,6 +56,7 @@ import io.grpc.ClientInterceptor;
 import io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
 import io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
 import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -64,11 +71,17 @@ class GrpcStatusMappingTest {
             sb.service(
                     GrpcService.builder()
                                .addService(new TestServiceImpl())
-                               .addExceptionMapping(A2Exception.class, Status.UNIMPLEMENTED)
-                               .addExceptionMapping(A3Exception.class, Status.UNAUTHENTICATED)
-                               .addExceptionMapping(B2Exception.class, Status.NOT_FOUND)
-                               .addExceptionMapping(B1Exception.class, Status.UNAUTHENTICATED)
+                               .addExceptionMapping(A3Exception.class,
+                                                    Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED"))
+                               .addExceptionMapping(A2Exception.class,
+                                                    Status.UNIMPLEMENTED.withDescription("UNIMPLEMENTED"))
                                .addExceptionMapping(A1Exception.class, Status.RESOURCE_EXHAUSTED)
+                               .addExceptionMapping(B2Exception.class,
+                                                    Status.NOT_FOUND.withDescription("NOT_FOUND"),
+                                                    it -> testMetadata("B2"))
+                               .addExceptionMapping(B1Exception.class,
+                                                    Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED"),
+                                                    it -> testMetadata("B1"))
                                .build());
         }
     };
@@ -80,22 +93,58 @@ class GrpcStatusMappingTest {
             sb.service(
                     GrpcService.builder()
                                .addService(new TestServiceImpl())
-                               .exceptionMapping(cause -> {
+                               .exceptionMapping((Function<Throwable, Status>) cause -> {
                                    if (cause instanceof A3Exception) {
-                                       return Status.UNAUTHENTICATED;
+                                       return Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED");
                                    }
                                    if (cause instanceof A2Exception) {
-                                       return Status.UNIMPLEMENTED;
+                                       return Status.UNIMPLEMENTED.withDescription("UNIMPLEMENTED");
                                    }
                                    if (cause instanceof A1Exception) {
                                        return Status.RESOURCE_EXHAUSTED;
                                    }
 
                                    if (cause instanceof B2Exception) {
-                                       return Status.NOT_FOUND;
+                                       return Status.NOT_FOUND.withDescription("NOT_FOUND");
                                    }
                                    if (cause instanceof B1Exception) {
-                                       return Status.UNAUTHENTICATED;
+                                       return Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED");
+                                   }
+                                   return null;
+                               })
+                               .build());
+        }
+    };
+
+    @RegisterExtension
+    static ServerExtension serverWithGrpcStatusFunction = new ServerExtension() {
+        @Override
+        protected void configure(ServerBuilder sb) throws Exception {
+            sb.service(
+                    GrpcService.builder()
+                               .addService(new TestServiceImpl())
+                               .exceptionMapping((GrpcStatusFunction) cause -> {
+                                   if (cause instanceof A3Exception) {
+                                       return ArmeriaGrpcStatus.of(
+                                               Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED"));
+                                   }
+                                   if (cause instanceof A2Exception) {
+                                       return ArmeriaGrpcStatus.of(
+                                               Status.UNIMPLEMENTED.withDescription("UNIMPLEMENTED"));
+                                   }
+                                   if (cause instanceof A1Exception) {
+                                       return ArmeriaGrpcStatus.of(Status.RESOURCE_EXHAUSTED);
+                                   }
+
+                                   if (cause instanceof B2Exception) {
+                                       return ArmeriaGrpcStatus.of(
+                                               Status.NOT_FOUND.withDescription("NOT_FOUND"),
+                                               testMetadata("B2"));
+                                   }
+                                   if (cause instanceof B1Exception) {
+                                       return ArmeriaGrpcStatus.of(
+                                               Status.UNAUTHENTICATED.withDescription("UNAUTHENTICATED"),
+                                               testMetadata("B1"));
                                    }
                                    return null;
                                })
@@ -108,24 +157,47 @@ class GrpcStatusMappingTest {
 
     @ArgumentsSource(ExceptionMappingsProvider.class)
     @ParameterizedTest
-    void serverExceptionMapping(RuntimeException exception, Status status) {
+    void serverExceptionMapping(RuntimeException exception, Status status, String description,
+                                Map<Metadata.Key<?>, String> meta) {
         exceptionRef.set(exception);
         final TestServiceBlockingStub client = Clients.newClient(
                 serverWithMapping.httpUri(GrpcSerializationFormats.PROTO),
                 TestServiceBlockingStub.class);
-        assertStatus(() -> client.emptyCall(Empty.getDefaultInstance()), status);
-        assertStatus(() -> client.unaryCall(SimpleRequest.getDefaultInstance()), status);
+        assertThatThrownBy(() -> client.emptyCall(Empty.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description))
+                .satisfies(throwable -> assertMetadata(throwable, meta));
+        assertThatThrownBy(() -> client.unaryCall(SimpleRequest.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description))
+                .satisfies(throwable -> assertMetadata(throwable, meta));
     }
 
     @ArgumentsSource(ExceptionMappingsProvider.class)
     @ParameterizedTest
-    void serverExceptionWithMappingFunction(RuntimeException exception, Status status) {
+    void serverExceptionWithMappingFunction(RuntimeException exception, Status status, String description) {
         exceptionRef.set(exception);
         final TestServiceBlockingStub client = Clients.newClient(
                 serverWithMappingFunction.httpUri(GrpcSerializationFormats.PROTO),
                 TestServiceBlockingStub.class);
-        assertStatus(() -> client.emptyCall(Empty.getDefaultInstance()), status);
-        assertStatus(() -> client.unaryCall(SimpleRequest.getDefaultInstance()), status);
+        assertThatThrownBy(() -> client.emptyCall(Empty.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description));
+        assertThatThrownBy(() -> client.unaryCall(SimpleRequest.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description));
+    }
+
+    @ArgumentsSource(ExceptionMappingsProvider.class)
+    @ParameterizedTest
+    void serverExceptionWithGrpcStatusFunction(RuntimeException exception, Status status, String description,
+                                               Map<Metadata.Key<?>, String> meta) {
+        exceptionRef.set(exception);
+        final TestServiceBlockingStub client = Clients.newClient(
+                serverWithGrpcStatusFunction.httpUri(GrpcSerializationFormats.PROTO),
+                TestServiceBlockingStub.class);
+        assertThatThrownBy(() -> client.emptyCall(Empty.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description))
+                .satisfies(throwable -> assertMetadata(throwable, meta));
+        assertThatThrownBy(() -> client.unaryCall(SimpleRequest.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, status, description))
+                .satisfies(throwable -> assertMetadata(throwable, meta));
     }
 
     @Test
@@ -137,11 +209,12 @@ class GrpcStatusMappingTest {
                        })
                        .build(TestServiceBlockingStub.class);
         // Make sure that a client call is closed when a exception is raised in a decorator.
-        assertStatus(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()), Status.UNKNOWN);
+        assertThatThrownBy(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, Status.UNKNOWN, null));
     }
 
     @Test
-    void clientExceptionMapping_interceptor() {
+    void clientException_interceptor() {
         final TestServiceBlockingStub client =
                 Clients.builder(serverWithMapping.httpUri(GrpcSerializationFormats.PROTO))
                        .build(TestServiceBlockingStub.class)
@@ -163,26 +236,38 @@ class GrpcStatusMappingTest {
                     }
                 });
         // Make sure that a client call is closed when a exception is raised in a client interceptor.
-        assertStatus(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()), Status.UNKNOWN);
+        assertThatThrownBy(() -> client.unaryCall2(SimpleRequest.getDefaultInstance()))
+                .satisfies(throwable -> assertStatus(throwable, Status.UNKNOWN, null));
     }
 
-    private static void assertStatus(ThrowingCallable task, Status status) {
-        final Throwable cause = catchThrowable(task);
-        final StatusRuntimeException statusException = (StatusRuntimeException) cause;
-        assertThat(statusException.getStatus().getCode()).isEqualTo(status.getCode());
+    private static void assertStatus(Throwable throwable, Status status, @Nullable String description) {
+        final StatusRuntimeException e = (StatusRuntimeException) throwable;
+        assertThat(e.getStatus().getCode()).isEqualTo(status.getCode());
+        assertThat(e.getStatus().getDescription()).isEqualTo(description);
+    }
+
+    private static void assertMetadata(Throwable throwable, Map<Metadata.Key<?>, String> entries) {
+        final StatusRuntimeException e = (StatusRuntimeException) throwable;
+        final Metadata metadata = e.getTrailers();
+        for (Entry<Key<?>, String> entry : entries.entrySet()) {
+            assertThat(metadata.get(entry.getKey())).isEqualTo(entry.getValue());
+        }
     }
 
     private static class ExceptionMappingsProvider implements ArgumentsProvider {
+        private static final Map<Metadata.Key<?>, String> EMPTY = ImmutableMap.of();
 
         @Override
         public Stream<? extends Arguments> provideArguments(ExtensionContext context) throws Exception {
             return Stream.of(
-                    Arguments.of(new A1Exception(), Status.RESOURCE_EXHAUSTED),
-                    Arguments.of(new A2Exception(), Status.UNIMPLEMENTED),
-                    Arguments.of(new A3Exception(), Status.UNAUTHENTICATED),
-                    Arguments.of(new B2Exception(), Status.NOT_FOUND),
-                    Arguments.of(new B1Exception(), Status.UNAUTHENTICATED),
-                    Arguments.of(new UnhandledException(), Status.UNKNOWN));
+                    Arguments.of(new A1Exception(), Status.RESOURCE_EXHAUSTED, null, EMPTY),
+                    Arguments.of(new A2Exception(), Status.UNIMPLEMENTED, "UNIMPLEMENTED", EMPTY),
+                    Arguments.of(new A3Exception(), Status.UNAUTHENTICATED, "UNAUTHENTICATED", EMPTY),
+                    Arguments.of(new B2Exception(), Status.NOT_FOUND, "NOT_FOUND",
+                                 ImmutableMap.of(TEST_KEY, "B2")),
+                    Arguments.of(new B1Exception(), Status.UNAUTHENTICATED, "UNAUTHENTICATED",
+                                 ImmutableMap.of(TEST_KEY, "B1")),
+                    Arguments.of(new UnhandledException(), Status.UNKNOWN, null, EMPTY));
         }
     }
 
@@ -203,6 +288,12 @@ class GrpcStatusMappingTest {
             responseObserver.onNext(SimpleResponse.getDefaultInstance());
             responseObserver.onCompleted();
         }
+    }
+
+    private static Metadata testMetadata(String value) {
+        Metadata metadata = new Metadata();
+        metadata.put(TEST_KEY, value);
+        return metadata;
     }
 
     static class A1Exception extends RuntimeException {
@@ -228,4 +319,7 @@ class GrpcStatusMappingTest {
     private static class UnhandledException extends RuntimeException {
         private static final long serialVersionUID = -2330757369375222959L;
     }
+
+    private static final Metadata.Key<String> TEST_KEY =
+            Metadata.Key.of("test_key", Metadata.ASCII_STRING_MARSHALLER);
 }


### PR DESCRIPTION
Motivation:
- upstream's issue
- Currently, we cannot write handling richer error with `GrpcStatusFunction`.

Modifications:
- Add `ArmeriaGrpcStatus` which holds `Status` and `Metadata`
- Change the signature `GrpcStatusFunction` to return `ArmeriaGrpcStatus`

Results:

We can write handling richer error with `GrpcStatusFunction`

```java
GrpcService.builder()
           ...
           .exceptionMapping((GrpcStatusFunction) cause -> {
               ...
               if (cause instanceof BusinessLogicException) {
                   return ArmeriaGrpcStatus.of(
                           Status.UNAUTHENTICATED.withDescription("you are not authenticated"),
                           toMetadata(cause));
               }
               ...
           })
           .build());
```